### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql01.yml
+++ b/.github/workflows/codeql01.yml
@@ -71,6 +71,9 @@ jobs:
   pr-check:
     name: Pull Request Compliance Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Validate PR title formatting (semantic commits)


### PR DESCRIPTION
Potential fix for [https://github.com/Kxanx1538/Meta-Front-End-Capstone-Project/security/code-scanning/4](https://github.com/Kxanx1538/Meta-Front-End-Capstone-Project/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `pr-check` job. This block will explicitly define the minimal permissions required for the job to function. Based on the functionality of the `amannn/action-semantic-pull-request` action, the job likely only needs `contents: read` and `pull-requests: read`. These permissions allow the job to read repository contents and pull request metadata without granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
