### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql01.yml
+++ b/.github/workflows/codeql01.yml
@@ -52,6 +52,8 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Kxanx1538/Meta-Front-End-Capstone-Project/security/code-scanning/3](https://github.com/Kxanx1538/Meta-Front-End-Capstone-Project/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `Unit Tests` job. Since this job only needs to read the repository contents to run tests, the minimal required permission is `contents: read`. This ensures the job does not inherit unnecessary permissions and adheres to the principle of least privilege.

The changes will be made to the `.github/workflows/codeql01.yml` file, specifically within the `Unit Tests` job definition. No additional methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
